### PR TITLE
Prevent last and first comic links from displaying incorrectly

### DIFF
--- a/app/views/comics/_comic_navigation.haml
+++ b/app/views/comics/_comic_navigation.haml
@@ -1,6 +1,6 @@
 %ul#comic-navigation
   %li#first-comic
-    -if @first_comic
+    -if @first_comic && @first_comic != @comic
       =link_to "First Comic", { :action => :show, :id => @first_comic.id }
     -else
       First Comic
@@ -17,7 +17,7 @@
     -else
       Next Comic
   %li#last-comic
-    -if @last_comic
+    -if @last_comic && @last_comic != @comic
       =link_to "Last Comic", :action => :show, :id => @last_comic.id
     -else
       Last Comic

--- a/app/views/comics/index.haml
+++ b/app/views/comics/index.haml
@@ -1,7 +1,1 @@
-%div#comic
-  %h2.comic-title
-    =@comic.title
-  %h3.comic-date
-    =@comic.post_date
-  =image_tag @comic.img_url, :class => "comic-image"
-  =render "comics/comic_navigation"
+=render :template => "comics/show", :locals => { :comic => @comic}


### PR DESCRIPTION
This PR prevents the first comic link from displaying on the first comic and likewise to the last comic link on the last comic.
