### PR TITLE
Fix errors in navigation.

### DIFF
--- a/app/models/comic.rb
+++ b/app/models/comic.rb
@@ -24,11 +24,11 @@ class Comic < ActiveRecord::Base
   end
 
   def self.next_comic(current_comic)
-    Comic.where('post_date > ?', current_comic.post_date).first
+    Comic.where('post_date > ?', current_comic.post_date).order(:post_date).first
   end
 
   def self.previous_comic(current_comic)
-    Comic.where('post_date < ?', current_comic.post_date).last
+    Comic.where('post_date < ?', current_comic.post_date).order(:post_date).last
   end
   
 end

--- a/app/views/comics/_comic_navigation.haml
+++ b/app/views/comics/_comic_navigation.haml
@@ -5,7 +5,7 @@
     -else
       First Comic
   %li#previous-comic
-    -if @previous_comic
+    -if @previous_comic && @first_comic != @comic
       =link_to "Previous Comic", :action => :show, :url_slug => @previous_comic.url_slug
     -else
       Previous Comic


### PR DESCRIPTION
This PR fixes errors where the site wasn't navigating through all comics in the site
due to the `next_comic` and `previous_comic` queries not being `order`ed before calling
them. I probably still need a better solution than calling a class method to get an individual
comic's next and previous values but this works for the time being.
