### PR TITLE
Add flexbox navigation.

### DIFF
--- a/app/assets/stylesheets/master.css
+++ b/app/assets/stylesheets/master.css
@@ -56,47 +56,99 @@ h6{
 #comic > img{
 }
 
-#comic-wrapper{
-	padding: 0;
-	margin: 0;
+#comic-and-nav-wrapper{
+	display: flex;
+	flex-flow: row || nowrap;
+	justify-content: center;
+	align-items: stretch;
+	align-content: space-between;
+}
+
+#first-comic a{
+	text-decoration:none;
+	color: #FFF;
+}
+
+#first-link:hover{
+	color: #ff00a3;
+	background-color: #ff00a3;
 }
 
 #first-comic{
-	display: inline-block;
+	color: #FFF;
 	width: 5%;
+}
+
+#first-link {
+	background: #FFF url("http://www.noncanon.com/2010/newdesign/comiccms/img/firstarrow.gif") no-repeat center;
+	min-height: 600px;
 	height: 100%;
-	padding-top: 50%;
-	padding-bottom: 50%;
+}
+
+#previous-comic a{
+	text-decoration:none;
+	color: #FFF;
 }
 
 #previous-comic{
-	display: inline-block;
-	width: 5%;
+	color: #FFF;
+	width: 10%;
+}
+
+#previous-link:hover{
+	color: #42ff00;
+	background-color: #42ff00;
+}
+
+#previous-link {
+	background: #FFF url("http://www.noncanon.com/2010/newdesign/comiccms/img/prevarrow.gif") no-repeat center;
+	min-height: 600px;
 	height: 100%;
-	padding-top: 50%;
-	padding-bottom: 50%;
 }
 
 #comic-image{
-	display: inline-block;
-	width: 76%;
-	vertical-align: top;
 }
 
 #next-comic{
-	display: inline-block;
-	width: 5%;
+	color: #FFF;
+	width: 10%;
+}
+
+#next-link:hover{
+	color: #f0ff00;
+	background-color: #f0ff00;
+}
+
+#next-comic a{
+	text-decoration: none;
+	color: #FFF;
+}
+
+#next-link {
+	background: #FFF url("http://www.noncanon.com/2010/newdesign/comiccms/img/nextarrow.gif") no-repeat center;
+	min-height: 600px;
 	height: 100%;
-	padding-top: 50%;
-	padding-bottom: 50%;
 }
 
 #last-comic{
-	display: inline-block;
+	color: #FFF;
 	width: 5%;
+}
+
+#last-comic a{
+	text-decoration:none;
+	color: #FFF;
+}
+
+#last-link:hover{
+	color: #00fcff;
+	background-color: #00fcff;
+}
+
+#last-link {
+	background: #FFF url("http://www.noncanon.com/2010/newdesign/comiccms/img/lastarrow.gif") no-repeat center;
+	min-height: 600px;
 	height: 100%;
-	padding-top: 50%;
-	padding-bottom: 50%;
 }
 
 #comic-footer{
@@ -161,3 +213,7 @@ ul.admin-nav {
 h4.comic-title {
 	color: #AE7400;
 }
+
+
+
+

--- a/app/views/comics/show.haml
+++ b/app/views/comics/show.haml
@@ -1,30 +1,37 @@
-%div#comic
-  %div#comic-wrapper
-    %div#first-comic
-      -if @first_comic && @first_comic != @comic
-        =link_to "First", { :action => :show, :url_slug => @first_comic.url_slug }
-      -else
-        First
-    %div#previous-comic
-      -if @previous_comic && @first_comic != @comic
-        =link_to "Prev", :action => :show, :url_slug => @previous_comic.url_slug
-      -else
-        Prev
-    %div#comic-image
-      -if @next_comic && @next_comic != @comic
-        =link_to(image_tag(@comic.img_url, :class => "comic-image"), :action => :show, :url_slug => @next_comic.url_slug)
-      -else
-        =image_tag @comic.img_url, :class => "comic-image"
-      %h4.comic-title
-        =@comic.title
-        =@comic.post_date.strftime(" - posted on %B %-d, %Y at %I:%M%P")
-    %div#next-comic
-      -if @next_comic && @next_comic != @comic
-        =link_to "Next", :action => :show, :url_slug => @next_comic.url_slug
-      -else
-        Next
-    %div#last-comic
-      -if @last_comic && @last_comic != @comic
-        =link_to "Last", :action => :show, :url_slug => @last_comic.url_slug
-      -else
-        Last
+%div#comic-and-nav-wrapper
+  %div#first-comic
+    -if @first_comic && @first_comic != @comic
+      %a{:href => "/comics/" + @first_comic.url_slug}
+        %div#first-link
+          First
+    -else
+      First
+  %div#previous-comic
+    -if @previous_comic && @first_comic != @comic
+      %a{:href => "/comics/" + @previous_comic.url_slug}
+        %div#previous-link
+          Previous 
+    -else
+      Previous
+  %div#comic-image
+    -if @next_comic && @next_comic != @comic
+      =link_to(image_tag(@comic.img_url, :class => "comic-image"), :action => :show, :url_slug => @next_comic.url_slug)
+    -else
+      =image_tag @comic.img_url, :class => "comic-image"
+    %h4.comic-title
+      =@comic.title
+      =@comic.post_date.strftime(" - posted on %B %-d, %Y at %I:%M%P")
+  %div#next-comic
+    -if @next_comic && @next_comic != @comic
+      %a{:href => "/comics/" + @next_comic.url_slug}
+        %div#next-link
+          Next
+    -else
+      Next
+  %div#last-comic
+    -if @last_comic && @last_comic != @comic
+      %a{:href => "/comics/" + @last_comic.url_slug}
+        %div#last-link
+          Last 
+    -else
+      Last


### PR DESCRIPTION
Closes #22.

This PR is a total re-write of the `comics/show` page and the accompanying CSS after another rewrite of the page and its CSS. Now the page uses flexbox which dramatically shrinks the amount of code required to display the links in a row with the comic image.
