### PR TITLE
Add environment to rake task.

### DIFF
--- a/lib/tasks/csv_import.rake
+++ b/lib/tasks/csv_import.rake
@@ -3,7 +3,7 @@ require 'net/http'
 
 ROOT_URL = "http://www.noncanon.com/comics/"
 
-task :dropbox_import do
+task :dropbox_import => :environment do
   tmp_file_name = "#{Rails.root}/tmp/db_comics.csv"
   Net::HTTP.start("noncanon.com") do |http|
     resp = http.get("/db_comics.csv")


### PR DESCRIPTION
This insures the Rails environment is loaded before the rake task is run so that it has access to models, etc.