### PR TITLE
Add Google Analytics.

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -1,0 +1,8 @@
+// Javascript
+$(document).on('page:change', function() {
+ if (window._gaq != null) {
+  return _gaq.push(['_trackPageview']);
+ } else if (window.pageTracker != null) {
+  return pageTracker._trackPageview();
+ }
+});

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,10 @@
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-36790335-1', 'noncanon.com');
+  ga('send', 'pageview');
+
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,5 +15,6 @@
 	</div>
 
   <%= render "comics/footer" %>
+  <%= render "layouts/footer" %>
 </body>
 </html>


### PR DESCRIPTION
Closes #80. 

This PR adds Turbolinks-friendly Google Analytics code and a footer partial to load it.