### PR TITLE
Add root url.

### DIFF
--- a/app/models/comic.rb
+++ b/app/models/comic.rb
@@ -1,10 +1,16 @@
 class Comic < ActiveRecord::Base
-  before_validation :slug_url
+  before_validation :slug_url, :add_root_url
+
+  ROOT_URL = "http://www.noncanon.online/comics/"
 
   def slug_url
     unless self.url_slug
       self.url_slug = self.title.parameterize
     end
+  end
+
+  def add_root_url
+    self.img_url = File.join(ROOT_URL, self.img_url)
   end
 
   def self.first_comic

--- a/spec/models/comic_spec.rb
+++ b/spec/models/comic_spec.rb
@@ -11,7 +11,9 @@ describe Comic do
     end
 
     it 'should return an image url' do
-      expect(comic.img_url).to eq("https://placehold.it/300x300.png/000")
+      comic.img_url = "test.png"
+      comic.save
+      expect(comic.img_url).to eq(Comic::ROOT_URL + "test.png")
     end
 
     it 'should return an alt text' do


### PR DESCRIPTION
This PR simplifies the comic creation process by only requiring the filename instead of the full URL path each time.