### PR TITLE
[hotfix] RSS Feed Dying

### DIFF
--- a/app/views/comics/_footer.haml
+++ b/app/views/comics/_footer.haml
@@ -6,7 +6,7 @@
 <p><a href="http://noncanon-comic.tumblr.com/">Tumblr</a> |
 <a href="https://twitter.com/noncanon_comic">Twitter</a> |
 <a href="https://www.facebook.com/noncanoncomicsandstories">Facebook</a> |
-<a href="feed.rss">RSS</a></p>
+<a href="/feed.rss">RSS</a></p>
 </div>
 <div id="footer-column2">
 <img src="http://www.noncanon.online/nav/Jan2014Avatar.png" align="right">
@@ -14,10 +14,10 @@
 
 <p>Cartoonist, anti-social, publisher, depressive, editor, braggart, game designer, coward, marathoner, medium talent.</p>
 <p><a href="https://twitter.com/tommchenry">@tommchenry</a> |
-<a href="http://machinery.tumblr.com/">Tumblr</a> | 
+<a href="http://machinery.tumblr.com/">Tumblr</a> |
 <a href="https://gumroad.com/tommchenry">Gumroad</a> |
 <a href="http://instagram.com/tommchenry">Instagram</a> |
-<a href="feed.rss">RSS</a> | 
+<a href="/feed.rss">RSS</a> |
 <a href="mailto:tommchenry@gmail.com">E-mail</a>
 </p>
 
@@ -31,5 +31,5 @@
 </div>
 &nbsp;
 </div>
-</div>          
+</div>
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,6 +6,7 @@ default: &default
 development:
   <<: *default
   database: webcomics_development
+  host: localhost
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".


### PR DESCRIPTION
This fixes a problem where users on pages with `/comics` URLS were getting sent to `noncanon.com/comics/feed.rss`, which activated the `Comics#show` controller action, which had no `current_comic` and so 500d.