### PR TITLE
Switch static links for S3

### DIFF
--- a/app/assets/stylesheets/master.css
+++ b/app/assets/stylesheets/master.css
@@ -82,7 +82,7 @@ h6{
 }
 
 #first-link {
-	background: #FFF url("http://www.noncanon.online/nav/firstarrow.gif") no-repeat center;
+	background: #FFF url("https://s3.amazonaws.com/noncanon-comics/img/firstarrow.gif") no-repeat center;
 	min-height: 600px;
 	height: 100%;
 }
@@ -103,7 +103,7 @@ h6{
 }
 
 #previous-link {
-	background: #FFF url("http://www.noncanon.online/nav/prevarrow.gif") no-repeat center;
+	background: #FFF url("https://s3.amazonaws.com/noncanon-comics/img/prevarrow.gif") no-repeat center;
 	min-height: 600px;
 	height: 100%;
 }
@@ -127,7 +127,7 @@ h6{
 }
 
 #next-link {
-	background: #FFF url("http://www.noncanon.online/nav/nextarrow.gif") no-repeat center;
+	background: #FFF url("https://s3.amazonaws.com/noncanon-comics/img/nextarrow.gif") no-repeat center;
 	min-height: 600px;
 	height: 100%;
 }
@@ -148,7 +148,7 @@ h6{
 }
 
 #last-link {
-	background: #FFF url("http://www.noncanon.online/nav/lastarrow.gif") no-repeat center;
+	background: #FFF url("https://s3.amazonaws.com/noncanon-comics/img/lastarrow.gif") no-repeat center;
 	min-height: 600px;
 	height: 100%;
 }

--- a/app/views/comics/_footer.haml
+++ b/app/views/comics/_footer.haml
@@ -9,7 +9,7 @@
 <a href="/feed.rss">RSS</a></p>
 </div>
 <div id="footer-column2">
-<img src="http://www.noncanon.online/nav/Jan2014Avatar.png" align="right">
+<img src="https://s3.amazonaws.com/noncanon-comics/img/Jan2014Avatar.png" align="right">
 <h1>Tom McHenry</h1>
 
 <p>Cartoonist, anti-social, publisher, depressive, editor, braggart, game designer, coward, marathoner, medium talent.</p>

--- a/app/views/comics/_header.haml
+++ b/app/views/comics/_header.haml
@@ -1,5 +1,5 @@
 = render "comics/comic_search_box"
 %div#logo-header
   %a(href="/")
-    %img(src="http://www.noncanon.online/nav/NonCanonLogo2014.png")
+    %img(src="https://s3.amazonaws.com/noncanon-comics/img/NonCanonLogo2014.png")
 


### PR DESCRIPTION
This PR takes the current static links for navigation and header images and makes them S3 links. This is part of a bigger change to switch all images from noncanon.online's unreliable image serving to using S3.