### PR TITLE
Update URLs

### DIFF
--- a/lib/tasks/img_url_update.rake
+++ b/lib/tasks/img_url_update.rake
@@ -1,5 +1,5 @@
-ORIGINAL_URL = "http://www.noncanon.com/"
-NEW_URL = "http://www.noncanon.online/"
+ORIGINAL_URL = "http://www.noncanon.online/"
+NEW_URL = "https://s3.amazonaws.com/noncanon-comics/"
 
 task :url_update => :environment do
   Comic.all.each do |comic|


### PR DESCRIPTION
Now that we've got a working S3 bucket and the public assets pointing to the right place, this PR updates the rake task used to mass reassign the comic image urls to point them to S3 instead of the old hosting site.