### PR TITLE
Paperclip Upload Integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem 'haml-rails'
 gem 'launchy'
 
 gem 'ransack'
+gem 'paperclip'
+gem 'aws-sdk', '~> 2.3'
+gem 'dotenv-rails', groups: [:development, :test]
 
 # Use RSpec for tests
 group :development, :test do
@@ -53,6 +56,7 @@ end
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
+  gem 'pry'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,14 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (6.0.4)
+    aws-sdk (2.10.110)
+      aws-sdk-resources (= 2.10.110)
+    aws-sdk-core (2.10.110)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.10.110)
+      aws-sdk-core (= 2.10.110)
+    aws-sigv4 (1.0.2)
     bcrypt (3.1.11)
     binding_of_caller (0.7.3)
       debug_inspector (>= 0.0.1)
@@ -51,6 +59,10 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    climate_control (0.2.0)
+    cocaine (0.5.8)
+      climate_control (>= 0.0.3, < 1.0)
+    coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -62,6 +74,10 @@ GEM
     crass (1.0.3)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
+    dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     erubis (2.7.0)
     execjs (2.7.0)
     faker (1.8.7)
@@ -88,6 +104,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jmespath (1.3.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -100,15 +117,30 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
+    method_source (0.8.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mimemagic (0.3.2)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     multi_json (1.12.2)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    paperclip (5.1.0)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
+      cocaine (~> 0.5.5)
+      mime-types
+      mimemagic (~> 0.3.0)
     pg (0.21.0)
     polyamorous (1.3.1)
       activerecord (>= 3.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     public_suffix (3.0.1)
     rack (1.6.8)
     rack-test (0.6.3)
@@ -182,6 +214,7 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     sexp_processor (4.10.0)
+    slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     sprockets (3.7.1)
@@ -214,16 +247,20 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk (~> 2.3)
   bcrypt (~> 3.1.7)
   byebug
   capybara
   coffee-rails (~> 4.1.0)
+  dotenv-rails
   faker
   haml-rails
   jbuilder (~> 2.0)
   jquery-rails
   launchy
+  paperclip
   pg
+  pry
   rails (= 4.2.5.1)
   ransack
   rspec-rails (~> 3.0)

--- a/app/assets/stylesheets/master.css
+++ b/app/assets/stylesheets/master.css
@@ -233,6 +233,7 @@ ul#search-results{
 
 li.single-result{
   list-style-type: none;
+  padding-bottom: 1em;
 }
 
 a.orange-link{
@@ -250,6 +251,12 @@ a.orange-link{
   height: 4%;
   padding-left: 80%;
   padding-top: .25%;
+}
+
+.search-link{
+  vertical-align: top;
+  padding-top: 8%;
+  display: inline-block;
 }
 
 #logo-header{

--- a/app/assets/stylesheets/master.css
+++ b/app/assets/stylesheets/master.css
@@ -46,6 +46,14 @@ h6{
 	color: #d68f00;
 }
 
+.first-column{
+  padding-left: 2%;
+}
+
+.last-column{
+  padding-right: 2%;
+}
+
 
 .list-all-comics a:visited {
 	color: #a87000;

--- a/app/controllers/admin/comics_controller.rb
+++ b/app/controllers/admin/comics_controller.rb
@@ -45,9 +45,9 @@ class Admin::ComicsController < ApplicationController
   end
 
   private
-  
+
   def comic_params
-    params.require(:comic).permit(:title, :alt_text, :img_url, :visible, :post_date, :keywords)
+    params.require(:comic).permit(:title, :alt_text, :image, :img_url, :visible, :post_date, :keywords)
   end
 
 end

--- a/app/models/comic.rb
+++ b/app/models/comic.rb
@@ -1,17 +1,19 @@
 class Comic < ActiveRecord::Base
-  before_validation :slug_url, :add_root_url, :ensure_post_date
+  before_validation :slug_url, :ensure_post_date
+  #Paperclip
+  has_attached_file :image,
+    styles: {
+    :thumb => "100x100#"
+    },
+    :convert_options => {
+      :thumb => "-quality 75 -strip" 
+    }
 
-  ROOT_URL = "http://www.noncanon.online/comics/"
+  validates_attachment_content_type :image, :content_type => /\Aimage\/.*\Z/
 
   def slug_url
     unless self.url_slug
       self.url_slug = self.title.parameterize
-    end
-  end
-
-  def add_root_url
-    unless self.img_url =~ /^(http|https):\/\//
-      self.img_url = File.join(ROOT_URL, self.img_url)
     end
   end
 
@@ -53,5 +55,4 @@ class Comic < ActiveRecord::Base
       order(:post_date).
       last
   end
-  
 end

--- a/app/views/admin/comics/edit.haml
+++ b/app/views/admin/comics/edit.haml
@@ -6,8 +6,8 @@
   =f.text_field :title
   =f.label :alt_text
   =f.text_field :alt_text
-  =f.label :img_url
-  =f.text_field :img_url
+  =f.label :image
+  =f.file_field :image
   =f.label :visible
   =f.check_box :visible
   =f.label :post_date
@@ -15,5 +15,5 @@
   =f.label :keywords
   =f.text_field :keywords
   =f.submit
-  
-=image_tag(@comic.img_url, :class => "comic-image")
+
+=image_tag(@comic.image.url, :class => "comic-image")

--- a/app/views/admin/comics/index.haml
+++ b/app/views/admin/comics/index.haml
@@ -2,13 +2,13 @@
 %div.current-comics
   %h2
     New Comic
-  =form_for ([:admin,@comic]) do |f|
+  =form_for([:admin,@comic]) do |f|
     =f.label :title
     =f.text_field :title
     =f.label :alt_text
     =f.text_field :alt_text
-    =f.label :img_url
-    =f.text_field :img_url
+    =f.label :image
+    =f.file_field :image
     =f.label :visible
     =f.check_box :visible
     =f.label :post_date

--- a/app/views/admin/comics/index.haml
+++ b/app/views/admin/comics/index.haml
@@ -27,6 +27,8 @@
         %td
           =link_to comic.title, comic_path(comic.url_slug)
         %td
+          =image_tag(comic.image.url(:thumb))
+        %td
           =comic.post_date.strftime("%B %-d, %Y at %I:%M %P") if comic.post_date
         %td
           ="Visible" if comic.visible

--- a/app/views/admin/comics/index.haml
+++ b/app/views/admin/comics/index.haml
@@ -1,6 +1,6 @@
 = render "admin/comics/admin_navigation"
 %div.current-comics
-  %h2
+  %h2.first-column
     New Comic
   =form_for([:admin,@comic]) do |f|
     =f.label :title
@@ -17,12 +17,12 @@
     =f.text_field :keywords
     =f.submit
 
-  %h2.comic-title
+  %h2.first-column
     All Comics
   %table.list-all-comics
     -@comics.each do |comic|
       %tr
-        %td
+        %td.first-column
           =comic.id if comic.id
         %td
           =link_to comic.title, comic_path(comic.url_slug)
@@ -34,5 +34,5 @@
           ="Visible" if comic.visible
         %td
           =link_to 'Edit', edit_admin_comic_path(comic.id)
-        %td
+        %td.last-column
           =link_to 'Delete', admin_comic_path(comic.id), method: :delete

--- a/app/views/comics/show.haml
+++ b/app/views/comics/show.haml
@@ -7,7 +7,8 @@
           %ul#search-results
             -@comics.each do |comic|
               %li.single-result
-                =link_to comic.title, comic_path(comic.url_slug), class: "orange-link"
+                =link_to image_tag(comic.image.url(:thumb)), comic_path(comic.url_slug)
+                =link_to comic.title, comic_path(comic.url_slug), class: "orange-link search-link"
         -else
           ="Sorry, No Comics Found For \"#{@searched_for}\""
   -else

--- a/app/views/comics/show.haml
+++ b/app/views/comics/show.haml
@@ -34,9 +34,9 @@
         %h6.random-link.padding-top-0.padding-bottom-10.margin-top-0.margin-bottom-0
           =link_to "Random Comic", { :action => :show, :url_slug => @random_comic.url_slug }, id: "random-link", class: "orange-link"
         -if @next_comic && @next_comic != @comic
-          =link_to(image_tag(@comic.img_url, :class => "comic-image", alt: @comic.alt_text, title: @comic.alt_text), :action => :show, :url_slug => @next_comic.url_slug)
+          =link_to(image_tag(@comic.image.url, :class => "comic-image", alt: @comic.alt_text, title: @comic.alt_text), :action => :show, :url_slug => @next_comic.url_slug)
         -else
-          =image_tag @comic.img_url, :class => "comic-image", alt: @comic.alt_text, title: @comic.alt_text
+          =image_tag @comic.image.url, :class => "comic-image", alt: @comic.alt_text, title: @comic.alt_text
       %div#next-comic
         -if @next_comic && @next_comic != @comic
           %a{:href => "/comic/" + @next_comic.url_slug}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,16 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  #S3 settings for paperclip
+  config.paperclip_defaults = {
+    storage: :s3,
+    :s3_protocol => :https,
+    s3_credentials: {
+      bucket: ENV.fetch('S3_BUCKET_NAME'),
+      access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID'),
+      secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
+      s3_region: ENV.fetch('AWS_REGION'),
+    }
+  }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,4 +76,16 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  #S3 settings for paperclip
+  config.paperclip_defaults = {
+    storage: :s3,
+    :s3_protocol => :https,
+    s3_credentials: {
+      bucket: ENV.fetch('S3_BUCKET_NAME'),
+      access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID'),
+      secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
+      s3_region: ENV.fetch('AWS_REGION'),
+    }
+  }
 end

--- a/db/migrate/20171230160132_add_images_to_comics.rb
+++ b/db/migrate/20171230160132_add_images_to_comics.rb
@@ -1,0 +1,9 @@
+class AddImagesToComics < ActiveRecord::Migration
+  def self.up
+    add_attachment :comics, :image
+  end
+
+  def self.down
+    remove_attachment :comics, :image
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161114013756) do
+ActiveRecord::Schema.define(version: 20171230160132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,8 +24,12 @@ ActiveRecord::Schema.define(version: 20161114013756) do
     t.datetime "updated_at"
     t.string   "url_slug"
     t.datetime "post_date"
-    t.boolean  "visible",    default: true
-    t.string   "keywords",   default: ""
+    t.boolean  "visible",            default: true
+    t.string   "keywords",           default: ""
+    t.string   "image_file_name"
+    t.string   "image_content_type"
+    t.integer  "image_file_size"
+    t.datetime "image_updated_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/tasks/paperclip_import.rake
+++ b/lib/tasks/paperclip_import.rake
@@ -1,0 +1,33 @@
+task :paperclip_import => :environment do
+  require "net/http"
+  total = Comic.count
+  count = 0
+  error_count = 0
+  errored_strips = []
+  Comic.all.each do |comic|
+    puts "Processing #{comic.title}"
+    count += 1
+    if comic.img_url
+      encoded_url = URI.encode(comic.img_url)
+      url = URI.parse(encoded_url)
+      req = Net::HTTP.new(url.host, url.port)
+      req.use_ssl = true
+      res = req.request_head(url.path)
+      if res.code == "200"
+        s3_url = comic.img_url
+        comic.image = s3_url
+        comic.save
+        puts "#{comic.title} processed. #{count} of #{total} complete!"
+      else
+        puts "ERROR! #{comic.title} could not be processed."
+        error_count +=1
+        errored_strips << comic.title
+      end
+    end
+  end
+  puts "Complete!"
+  puts "#{error_count} strips errored out:"
+  errored_strips.each do |error|
+    puts error
+  end
+end

--- a/spec/models/comic_spec.rb
+++ b/spec/models/comic_spec.rb
@@ -10,12 +10,6 @@ describe Comic do
       expect(comic.title).to eq("Test Comic")
     end
 
-    it 'should return an image url' do
-      comic.img_url = "test.png"
-      comic.save
-      expect(comic.img_url).to eq(Comic::ROOT_URL + "test.png")
-    end
-
     it 'should return an alt text' do
       expect(comic.alt_text).to eq("alt text")
     end


### PR DESCRIPTION
This PR adds upload forms for all comic images via Paperclip to S3. It also adds dot_env for storing secret keys, a thumbnail view of each comic (and adds those views in admin and the search view)

Additionally there's a rake task that will need to be run to process the current S3 urls into actual attachments for the individual comics. After this is done, there should be a fast follow to create a migration to delete the `img_url` column in the DB.