### PR TITLE
Validates presence of title

### DIFF
--- a/app/models/comic.rb
+++ b/app/models/comic.rb
@@ -19,6 +19,8 @@
 
 class Comic < ActiveRecord::Base
   before_validation :slug_url, :ensure_post_date
+  validates :title, presence: true
+
   #Paperclip
   has_attached_file :image,
     styles: {


### PR DESCRIPTION
This fixes a problem I had recently: in a rush I accidentally hit post on a blank comic, and the `nil` values all over made everything 500, forcing me to go into console and destroy the offending object.

This PR just adds a validation that forces a comic to have a title in order to be submitted.