### PR TITLE
Update the Ruby Version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby '2.6.5'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '6.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1232,5 +1232,8 @@ DEPENDENCIES
   uglifier
   web-console
 
+RUBY VERSION
+   ruby 2.6.5p114
+
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
Heroku's not seeing the `.ruby_version` file, so we're updating it in the Gemfile, too. Here goes nothing!