### PR TITLE
Remove before_filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /log/*
 !/log/.keep
 /tmp
+.env

--- a/app/controllers/admin/comics_controller.rb
+++ b/app/controllers/admin/comics_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ComicsController < ApplicationController
-  before_filter :authorize
-  before_filter :publisher
+  before_action :authorize
+  before_action :publisher
 
   def index
     @search = Comic.search(params[:q])

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,6 @@
 class Admin::DashboardController < ApplicationController
-  before_filter :authorize
-  before_filter :publisher
+  before_action :authorize
+  before_action :publisher
 
   def index
     @comic = Comic.new


### PR DESCRIPTION
Rails 5 swapped `before_filter` for `before_action` so this needs to be updated. Weirdly this had no problem running locally.